### PR TITLE
Add basic Vitest setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ HealthCentral is a medication management application built with React, Vite and 
 - `npm run build` – create a production build
 - `npm run build:dev` – build with development settings
 - `npm run lint` – run ESLint
+- `npm run test` – run unit tests
 - `npm run preview` – preview the production build locally
 
 ## License

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "build:dev": "vite build --mode development",
+    "test": "vitest",
     "lint": "eslint .",
     "preview": "vite preview"
   },
@@ -81,6 +82,8 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/tests/example.test.ts
+++ b/tests/example.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('math', () => {
+  it('adds numbers', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,13 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  test: {
+    environment: 'jsdom',
+  },
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- add an example unit test
- configure Vitest in `vite.config.ts`
- add `vitest` and `jsdom` dev deps
- document test script in README

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6269cae4832fb81b94738433e142