### PR TITLE
Fix Supabase env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ HealthCentral is a medication management application built with React, Vite and 
    SUPABASE_URL=<your-supabase-url>
    SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
    ```
-   The service role key is only used by server-side Supabase functions.
+   These values are required for signup and login to work. If they are missing, registration will fail. The service role key is only used by server-side Supabase functions.
 4. Start the development server:
    ```sh
    npm run dev

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -3,8 +3,12 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://lvpeknlczknywtapbcsq.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imx2cGVrbmxjemtueXd0YXBiY3NxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzQ2OTk4MzYsImV4cCI6MjA1MDI3NTgzNn0.9vCVlKAZXgOPoxxjNAwMY8qC5Jjcj49zXQPVHJkzksM";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
+  throw new Error('Missing Supabase environment variables. Check your .env file.');
+}
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
## Summary
- use environment variables for Supabase client creation
- check for missing env vars so signup fails fast
- document required env vars for authentication

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_686a66ad6de8832fb32f494c6b8c1c0c